### PR TITLE
convert code to use params across the board

### DIFF
--- a/controllers/whichEnglish.js
+++ b/controllers/whichEnglish.js
@@ -39,7 +39,7 @@ module.exports = (rpc, conn, dbWrite) => {
     const { user, choiceId, questionId } = req.body;
     var rpcInput = {
       method: 'allResponses',
-      arguments: []
+      params: []
     };
     const channelName = fileName + '_rpc_worker';
     return rpc(conn, channelName, rpcInput)
@@ -55,7 +55,7 @@ module.exports = (rpc, conn, dbWrite) => {
     // respond
     var rpcInput = {
       method: 'createResponse',
-      arguments: [{ userId: user.id, choiceId }]
+      params: [{ userId: user.id, choiceId }]
     };
     return dbWrite(conn, fileName + '_db_write', rpcInput)
       .then(() => {
@@ -76,7 +76,7 @@ module.exports = (rpc, conn, dbWrite) => {
   router.put('/users/:id', (req, res, next) => {
     var rpcInput = {
       method: 'updateUser',
-      arguments: [req.params.id, req.body]
+      params: [req.params.id, req.body]
     };
     const channelName = fileName + '_rpc_worker';
     return rpc(conn, channelName, rpcInput)
@@ -135,7 +135,7 @@ module.exports = (rpc, conn, dbWrite) => {
   router.get('/users/:id', (req, res, next) => {
     var rpcInput = {
       method: 'findUser',
-      arguments: [req.params.id, ['userLanguages.languages']]
+      params: [req.params.id, ['userLanguages.languages']]
     };
     const channelName = fileName + '_rpc_worker';
     return rpc(conn, channelName, rpcInput)
@@ -158,7 +158,7 @@ module.exports = (rpc, conn, dbWrite) => {
   router.post('/comments', (req, res, next) => {
     var rpcInput = {
       method: 'setUserLanguages',
-      arguments: [
+      params: [
         req.body.userId,
         {
           nativeLanguages: req.body.nativeLanguages,
@@ -171,7 +171,7 @@ module.exports = (rpc, conn, dbWrite) => {
       .then(data => {
         var rpc2 = {
           method: 'updateUser',
-          arguments: [
+          params: [
             req.body.userId,
             {
               countriesOfResidence: req.body.countryOfResidence

--- a/test/whichEnglishControllerTest.js
+++ b/test/whichEnglishControllerTest.js
@@ -97,7 +97,7 @@ describe('WHICH English Controller', () => {
           const connection = 'fake connection';
           const body = {
             method: 'allResponses',
-            arguments: []
+            params: []
           };
           const wasCalledWithArgs = mockRpc.calledWith(
             connection,
@@ -110,7 +110,7 @@ describe('WHICH English Controller', () => {
           expect(rpcArguments[1]).to.eql('whichenglish_rpc_worker');
           expect(rpcArguments[2]).to.eql({
             method: 'allResponses',
-            arguments: []
+            params: []
           });
           expect(wasCalledWithArgs).to.be.true;
           return response;
@@ -149,12 +149,12 @@ describe('WHICH English Controller', () => {
           expect(dbWriterArguments[1]).to.eql('whichenglish_db_write');
           expect(dbWriterArguments[2]).to.eql({
             method: 'createResponse',
-            arguments: [{ userId: 1, choiceId: 1 }]
+            params: [{ userId: 1, choiceId: 1 }]
           });
           expect(
             mockDbWrite.calledWith('fake connection', 'whichenglish_db_write', {
               method: 'createResponse',
-              arguments: [{ userId: 1, choiceId: 1 }]
+              params: [{ userId: 1, choiceId: 1 }]
             })
           ).to.be.true;
         });
@@ -229,7 +229,7 @@ describe('WHICH English Controller', () => {
           expect(mockRpc.firstCall.args[1]).to.equal('whichenglish_rpc_worker');
           expect(mockRpc.firstCall.args[2]).to.eql({
             method: 'updateUser',
-            arguments: [userId, { age: 5, gender: 'female' }]
+            params: [userId, { age: 5, gender: 'female' }]
           });
         });
     });
@@ -416,7 +416,7 @@ describe('WHICH English Controller', () => {
         expect(mockRpc.firstCall.args[1]).to.equal('whichenglish_rpc_worker');
         expect(mockRpc.firstCall.args[2]).to.eql({
           method: 'findUser',
-          arguments: [userId, ['userLanguages.languages']]
+          params: [userId, ['userLanguages.languages']]
         });
       });
     });
@@ -478,7 +478,7 @@ describe('WHICH English Controller', () => {
             'whichenglish_rpc_worker',
             {
               method: 'setUserLanguages',
-              arguments: [
+              params: [
                 userId,
                 {
                   nativeLanguages: ['chinese', 'english'],
@@ -521,7 +521,7 @@ describe('WHICH English Controller', () => {
             'whichenglish_rpc_worker',
             {
               method: 'updateUser',
-              arguments: [
+              params: [
                 userId,
                 {
                   countriesOfResidence: 'china,usa',


### PR DESCRIPTION
Rather than using `arguments` db-worker and and `params` for python-worker